### PR TITLE
Develop wp error

### DIFF
--- a/includes/wc-ecster-functions.php
+++ b/includes/wc-ecster-functions.php
@@ -85,7 +85,6 @@ function ecster_create_order() {
 			$error_detail  = isset( $response_body->message ) ? $response_body->message : '';
 		}
 		WC_Gateway_Ecster::log( 'Ecster create cart ' . $error_title . ': ' . $error_detail );
-		WC_Gateway_Ecster::log( 'Ecster create cart ' . $error_title . ': ' . $error_detail );
 		return __( 'Error: Ecster Pay create cart request failed ' . $error_title . ' (' . $error_detail . ').', 'krokedil-ecster-pay-for-woocommerce' );
 	}
 }


### PR DESCRIPTION
Check if the response is a `WP_Error` before trying to decode it.

```
Ett fel av typen E_ERROR uppstod på rad 99 i följande fil: /home/site/domains/site.se/public_html/wp-content/plugins/krokedil-ecster-pay-v2-for-woocommerce/includes/class-wc-ecster-order-management.php. Felorsak: Uncaught Error: Cannot use object of type WP_Error as array in /home/site/domains/site.se/public_html/wp-content/plugins/krokedil-ecster-pay-v2-for-woocommerce/includes/class-wc-ecster-order-management.php:99
Stack trace:
#0 /home/site/domains/site.se/public_html/wp-includes/class-wp-hook.php(309): WC_Ecster_Order_Management->complete_ecster_order()
#1 /home/site/domains/site.se/public_html/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters()
#2 /home/site/domains/site.se/public_html/wp-includes/plugin.php(474): WP_Hook->do_action()
#3 /home/site/domains/site.se/public_html/wp-content/plugins/woocommerce/includes/class-wc-order.php(364): do_action()
#4 /home/site/domains/site.se/public_html/wp-content/plugins/woocommerce/includes/class-wc-order.php(222): WC_Order->status_transition()
#5 /home/site/domains/site.se/public_html/wp-content/plugins/woocommerce/includes/class-wc-order.php(334): WC_Order->save()
#6 /home/site/domains/site.se/public_html/wp-content/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php(684): WC_Order->update_status()
#7 /home/site/domains/site.se/public_html/wp-includes/class-wp-hook.php(307): WC_Admin_List_Table_Orders->handle_bulk_actions()
#8 /home/site/domains/site.se/public_html/wp-includes/plugin.php(189): WP_Hook->apply_filters()
#9 /home/site/domains/site.se/public_html/wp-admin/edit.php(212): apply_filters()
#10 {main}
thrown
```